### PR TITLE
Cleanup Travis and tox configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: python
+
 python:
   - "2.7"
   - "3.3"
@@ -7,42 +8,15 @@ python:
   - "3.5"
   - "3.6"
   - "pypy"
-env:
-  matrix:
-    - DJANGO="Django>=1.7,<1.8"
-    - DJANGO="Django>=1.8,<1.9"
-    - DJANGO="Django>=1.9,<1.10"
-    - DJANGO="Django>=1.10,<1.11"
-    - DJANGO="Django>=1.11,<1.12"
-    - DJANGO="--pre django"
+
 install:
-  - pip install $DJANGO
-  - pip install coveralls
-  - pip install --upgrade -r dev-requirements.txt
+  - pip install coveralls tox-travis
+
 script:
-  - inv test
-after_success:
-  - coveralls
+  - tox
+
 matrix:
   fast_finish: true
-  exclude:
-    - python: "3.3"
-      env: DJANGO="Django>=1.9,<1.10"
-    - python: "3.3"
-      env: DJANGO="Django>=1.10,<1.11"
-    - python: "3.3"
-      env: DJANGO="Django>=1.11,<1.12"
-    - python: "3.3"
-      env: DJANGO="--pre django"
-    - python: "3.5"
-      env: DJANGO="Django>=1.7,<1.8"
-    - python: "3.6"
-      env: DJANGO="Django>=1.7,<1.8"
-    - python: "3.6"
-      env: DJANGO="Django>=1.8,<1.9"
-    - python: "3.6"
-      env: DJANGO="Django>=1.9,<1.10"
-    - python: "3.6"
-      env: DJANGO="Django>=1.10,<1.11"
-  allow_failures:
-    - env: DJANGO="--pre django"
+
+after_success:
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ script:
 
 matrix:
   fast_finish: true
+  include:
+    - python: "3.6"
+      env: TOX_ENV=docs
+      script: tox -e $TOX_ENV
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ matrix:
     - python: "3.6"
       env: TOX_ENV=docs
       script: tox -e $TOX_ENV
+    - python: "3.6"
+      env: TOX_ENV=flake8
+      script: tox -e $TOX_ENV
 
 after_success:
   - coveralls

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,10 @@
 -e .
+django
+flake8
 invoke>=0.11.1,<0.12
+pytest
+pytest-cov
+pytest-django
 tox
 twine
 wheel

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,6 @@
 -e .
 flake8<3.0
 invoke>=0.11.1,<0.12
-pytest
-pytest-cov
-pytest-django
 sphinx
 sphinx_rtd_theme
 tox

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,8 +1,5 @@
 -e .
-flake8<3.0
 invoke>=0.11.1,<0.12
-sphinx
-sphinx_rtd_theme
 tox
 twine
 wheel

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -128,7 +128,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+#html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -72,7 +72,7 @@ the package will look for ``elevate/elevate.html`` but can easily be overwritten
 ``template_name`` when defining the url definition as seen above.
 
 elevate/elevate.html
---------------
+--------------------
 
 This template gets rendered with the the following context:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 python_files = tests/*.py
 
 [flake8]

--- a/tasks.py
+++ b/tasks.py
@@ -8,7 +8,7 @@ run = partial(_run, echo=True, pty=True)
 @task
 def lint(verbose=False):
     "Run flake8 linter"
-    run('flake8 elevate tests *.py {0}'.format('-v' if verbose else ''))
+    run('tox -e flake8{0}'.format(' -- -v' if verbose else ''))
 
 
 @task(lint)

--- a/tasks.py
+++ b/tasks.py
@@ -13,8 +13,8 @@ def lint(verbose=False):
 
 @task(lint)
 def test(verbose=False):
-    "Run tests using py.test"
-    run('py.test --cov elevate --cov-report term-missing {0}'.format('-v' if verbose else ''))
+    "Run tests using tox"
+    run('tox --skip-missing-interpreters{0}'.format(' -- -v' if verbose else ''))
 
 
 @task

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -8,6 +8,7 @@ class FooView(ElevateMixin, generic.View):
     def get(self, request):
         return HttpResponse()
 
+
 foo = FooView.as_view()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py33-django17
     py35-django{18,19,110,111}
     py36-django111
+    docs
 
 [testenv]
 deps =
@@ -17,6 +18,14 @@ deps =
     pytest-cov
     pytest-django
 commands = py.test --cov elevate --cov-report term-missing {posargs}
+
+[testenv:docs]
+basepython=python
+changedir=docs
+commands=sphinx-build -W -b html -d _build/doctrees . _build/html
+deps=
+  sphinx
+  sphinx_rtd_theme
 
 [travis]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py35-django{18,19,110,111}
     py36-django111
     docs
+    flake8
 
 [testenv]
 deps =
@@ -26,6 +27,11 @@ commands=sphinx-build -W -b html -d _build/doctrees . _build/html
 deps=
   sphinx
   sphinx_rtd_theme
+
+[testenv:flake8]
+basepython=python
+commands=flake8 elevate tests *.py {posargs}
+deps=flake8
 
 [travis]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,28 @@
 [tox]
-envlist = py26-django14, py27, py32, py33, py34, pypy
+envlist =
+    {pypy,py27,py34}-django{17,18,19,110,111}
+    py33-django17
+    py35-django{18,19,110,111}
+    py36-django111
 
 [testenv]
 deps =
-       django14: django >=1.4.2,<1.5
-       pytest
-       pytest-cov
-       pytest-django
-commands = py.test --cov elevate --cov-report term-missing
+    django17: Django>=1.7,<1.8
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<1.12
+    coverage>=4.1
+    pytest
+    pytest-cov
+    pytest-django
+commands = py.test --cov elevate --cov-report term-missing {posargs}
+
+[travis]
+python =
+    2.7: py27
+    3.3: py33
+    3.4: py34
+    3.5: py35
+    3.6: py36
+    pypy: pypy


### PR DESCRIPTION
Cleaned up the Travis and tox configs, including some bits missed in my PR to django-sudo:

* Moved the environment list completely to tox, which should be easier to read given how we need to exclude quite a few Django/Python combinations
* Added linting and doc building to tox and fixed a few issues
* Linting and doc building are done as separate jobs on Travis
* Kept all this compatible with the already defined `invoke` tasks
* Removed dependencies from `dev-requirements.txt` that are no longer needed