### PR TITLE
Remove vendored is_safe_url; drop Django 1.7 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Installation
 
 Compatibility
 ~~~~~~~~~~~~~
-* Django 1.7 - 1.11
+* Django 1.8 - 1.11
 * Python 2.7 - 3.6
 * pypy
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ Installation
 
 Compatibility
 ~~~~~~~~~~~~~
-* Django 1.7 - 1.11
+* Django 1.8 - 1.11
 * Python 2.7 - 3.6
 * pypy
 

--- a/elevate/utils.py
+++ b/elevate/utils.py
@@ -6,13 +6,8 @@ elevate.utils
 :copyright: (c) 2014-2016 by Matt Robenolt.
 :license: BSD, see LICENSE for more details.
 """
-import unicodedata
-
 from django.core.signing import BadSignature
-from django.utils import six
 from django.utils.crypto import get_random_string, constant_time_compare
-from django.utils.encoding import force_text
-from django.utils.six.moves.urllib.parse import urlparse
 
 from elevate.settings import COOKIE_NAME, COOKIE_AGE, COOKIE_SALT
 
@@ -66,44 +61,3 @@ def has_elevated_privileges(request):
         except (KeyError, BadSignature):
             request._elevate = False
     return request._elevate
-
-
-def is_safe_url(url, host=None):
-    """
-    Return ``True`` if the url is a safe redirection (i.e. it doesn't point to
-    a different host and uses a safe scheme).
-    Always returns ``False`` on an empty url.
-    """
-    if url is not None:
-        url = url.strip()
-    if not url:
-        return False
-    if six.PY2:  # pragma: nocover
-        try:
-            url = force_text(url)
-        except UnicodeDecodeError:
-            return False
-    # Chrome treats \ completely as / in paths but it could be part of some
-    # basic auth credentials so we need to check both URLs.
-    return _is_safe_url(url, host) and _is_safe_url(url.replace('\\', '/'), host)
-
-
-def _is_safe_url(url, host):
-    # Chrome considers any URL with more than two slashes to be absolute, but
-    # urlparse is not so flexible. Treat any url with three slashes as unsafe.
-    if url.startswith('///'):
-        return False
-    url_info = urlparse(url)
-    # Forbid URLs like http:///example.com - with a scheme, but without a hostname.
-    # In that URL, example.com is not the hostname but, a path component. However,
-    # Chrome will still consider example.com to be the hostname, so we must not
-    # allow this syntax.
-    if not url_info.netloc and url_info.scheme:
-        return False
-    # Forbid URLs that start with control characters. Some browsers (like
-    # Chrome) ignore quite a few control characters at the start of a
-    # URL and might consider the URL as scheme relative.
-    if unicodedata.category(url[0])[0] == 'C':
-        return False
-    return ((not url_info.netloc or url_info.netloc == host) and
-            (not url_info.scheme or url_info.scheme in ('http', 'https')))

--- a/elevate/views.py
+++ b/elevate/views.py
@@ -21,11 +21,12 @@ from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect
 from django.views.generic import View
 from django.utils.decorators import method_decorator
+from django.utils.http import is_safe_url
 from django.utils.module_loading import import_string
 
 from elevate.settings import (REDIRECT_FIELD_NAME, REDIRECT_URL,
                               REDIRECT_TO_FIELD_NAME, URL)
-from elevate.utils import grant_elevated_privileges, is_safe_url
+from elevate.utils import grant_elevated_privileges
 from elevate.forms import ElevateForm
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,6 @@ from elevate.utils import (
     grant_elevated_privileges,
     revoke_elevated_privileges,
     has_elevated_privileges,
-    is_safe_url,
 )
 
 from django.core.signing import BadSignature
@@ -103,29 +102,3 @@ class HasElevatedPrivilegesTestCase(BaseTestCase):
     def test_missing_keys(self):
         self.login()
         self.assertFalse(has_elevated_privileges(self.request))
-
-
-class IsSafeUrlTestCase(BaseTestCase):
-    def test_success(self):
-        urls = (
-            ('/', None),
-            ('/foo/', None),
-            ('/', 'example.com'),
-            ('http://example.com/foo', 'example.com'),
-        )
-        for url in urls:
-            self.assertTrue(is_safe_url(*url))
-
-    def test_failure(self):
-        urls = (
-            (None, None),
-            ('', ''),
-            ('http://mattrobenolt.com/', 'example.com'),
-            ('///example.com/', None),
-            ('ftp://example.com', 'example.com'),
-            ('http://example.com\@mattrobenolt.com', 'example.com'),
-            ('http:///example.com', 'example.com'),
-            ('\x08//example.com', 'example.com'),
-        )
-        for url in urls:
-            self.assertFalse(is_safe_url(*url))

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,13 @@
 [tox]
 envlist =
-    {pypy,py27,py34}-django{17,18,19,110,111}
-    py33-django17
-    py35-django{18,19,110,111}
+    {pypy,py27,py34,py35}-django{18,19,110,111}
+    py33-django18
     py36-django111
     docs
     flake8
 
 [testenv]
 deps =
-    django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11


### PR DESCRIPTION
Fixes #2 

Also drop support for Django 1.7. Technically this package will still work with Django 1.7, but as pointed out in #2 Django 1.7 still has some security issues that have been since fixed in 1.8+