### PR TITLE
Minor flake8 fixes

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,7 +17,7 @@ class GrantElevatedPrivilegesTestCase(BaseTestCase):
         token = request.session[COOKIE_NAME]
 
         self.assertRegexpMatches(
-            token, '^\w{12}$'
+            token, r'^\w{12}$'
         )
         self.assertTrue(request._elevate)
         self.assertEqual(request._elevate_token, token)

--- a/tests/views.py
+++ b/tests/views.py
@@ -60,7 +60,7 @@ class ElevateViewTestCase(BaseTestCase):
         response = elevate(self.request)
         self.assertEqual(response['Location'], REDIRECT_URL)
         self.request.GET = {
-            REDIRECT_FIELD_NAME: 'http://%s\@mattrobenolt.com' % self.request.get_host(),
+            REDIRECT_FIELD_NAME: 'http://%s\\@mattrobenolt.com' % self.request.get_host(),
         }
         response = elevate(self.request)
         self.assertEqual(response['Location'], REDIRECT_URL)
@@ -114,7 +114,7 @@ class ElevateViewTestCase(BaseTestCase):
         self.assertEqual(response['Location'], REDIRECT_URL)
         self.assertFalse('redirect_to' in self.request.session)
         self.request.session[REDIRECT_TO_FIELD_NAME] = (
-            'http://%s\@mattrobenolt.com' % self.request.get_host()
+            'http://%s\\@mattrobenolt.com' % self.request.get_host()
         )
         response = elevate(self.request)
         self.assertEqual(response['Location'], REDIRECT_URL)


### PR DESCRIPTION
At some point in the future, Python will error when it comes across an
invalid escape sequence. A DeprecationWarning is given starting with
Python 3.6