### PR TITLE
Test against Django 2.1

### DIFF
--- a/elevate/utils.py
+++ b/elevate/utils.py
@@ -7,7 +7,9 @@ elevate.utils
 :license: BSD, see LICENSE for more details.
 """
 from django.core.signing import BadSignature
+from django.utils import http
 from django.utils.crypto import get_random_string, constant_time_compare
+import django
 
 from elevate.settings import COOKIE_NAME, COOKIE_AGE, COOKIE_SALT
 
@@ -76,3 +78,13 @@ def is_authenticated(user):
         return user.is_authenticated()
     else:
         return user.is_authenticated
+
+
+def is_safe_url(url, allowed_hosts, require_https=False):
+    """
+    Wrapper around is_safe_url for Django versions < 1.11
+    """
+    if django.VERSION >= (1, 11):
+        return http.is_safe_url(url, allowed_hosts=allowed_hosts, require_https=require_https)
+    else:
+        return http.is_safe_url(url, allowed_hosts[0])

--- a/tests/base.py
+++ b/tests/base.py
@@ -15,7 +15,7 @@ class StubPasswordBackend(object):
     """
     password = "stub"
 
-    def authenticate(self, username, password):
+    def authenticate(self, request=None, username=None, password=None):
         if password == self.password:
             return User()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist =
     {pypy,py27}-django{18,19,110,111}
-    {py34,py35}-django{18,19,110,111,20}
-    {py36,py37}-django{111,20}
+    py34-django{18,19,110,111,20}
+    py35-django{18,19,110,111,20,21}
+    {py36,py37}-django{111,20,21}
     docs
     flake8
 
@@ -13,6 +14,7 @@ deps =
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
     django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
     coverage>=4.1
     pytest
     pytest-cov


### PR DESCRIPTION
A few minor changes for 2.1 were reuired:

- `is_safe_url` has dropped the `host` kwarg
- `authenticate` expects a `request` kwarg