### PR TITLE
Django 2.2 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,8 +31,8 @@ Installation
 
 Compatibility
 ~~~~~~~~~~~~~
-* Django 1.8 - 2.0
-* Python 2.7 - 3.6
+* Django 1.8 - 2.2
+* Python 2.7 - 3.7
 * pypy
 
 Resources

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,8 +23,8 @@ Installation
 
 Compatibility
 ~~~~~~~~~~~~~
-* Django 1.8 - 1.11
-* Python 2.7 - 3.6
+* Django 1.8 - 2.2
+* Python 2.7 - 3.7
 * pypy
 
 Contents

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     {pypy,py27}-django{18,19,110,111}
     py34-django{18,19,110,111,20}
-    py35-django{18,19,110,111,20,21}
-    {py36,py37}-django{111,20,21}
+    py35-django{18,19,110,111,20,21,22}
+    {py36,py37}-django{111,20,21,22}
     docs
     flake8
 
@@ -15,6 +15,7 @@ deps =
     django111: Django>=1.11,<1.12
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
+    django22: Django>=2.2,<2.3
     coverage>=4.1
     pytest
     pytest-cov


### PR DESCRIPTION
Django 2.2 support

Nothing needed changing for tests to pass. Also updated the readme and docs with currently supported versions of Python and Django.