### PR TITLE
Remove dot from the pytest command

### DIFF
--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -31,7 +31,7 @@ Tests can simply be run using:
 
 .. code-block:: console
 
-    $ py.test
+    $ pytest
 
 This will discover and run the test suite using your default Python interpreter. To run tests
 for all supported platforms, we use `tox <https://pypi.python.org/pypi/tox>`_.


### PR DESCRIPTION
removed the dot on the pytest command. From pytest version 3.0 is no longer needed and it's deprecated.