### PR TITLE
Housekeeping

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"

--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ pip-log.txt
 # Unit test / coverage reports
 .coverage
 .tox
-nosetests.xml
+coverage.xml
 
 # Translations
 *.mo

--- a/README.rst
+++ b/README.rst
@@ -47,8 +47,8 @@ Installation
 Compatibility
 ~~~~~~~~~~~~~
 
-* Django 2.2, 3.1, and 3.2
-* Python 3.5 - 3.10
+* Django 2.2, 3.2, and 4.0
+* Python 3.7 - 3.10
 * pypy3
 
 .. inclusion-marker-do-not-remove-end

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+Release type: patch
+
+- Added Django 4.0 support
+    - Added ELEVATE_TOKEN_LENGTH setting as `get_random_string` no longer has a
+      default length
+- Removed Django 3.1 from test matrix
+- Removed Python 3.6 from test matrix
+- No longer build wheel as universal - we don't support Python 2

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,7 @@
 Release type: patch
 
-- Added Django 4.0 support
-    - Added ELEVATE_TOKEN_LENGTH setting as `get_random_string` no longer has a
-      default length
-- Removed Django 3.1 from test matrix
-- Removed Python 3.6 from test matrix
-- No longer build wheel as universal - we don't support Python 2
+- Add Django 4.0 support
+- Add `ELEVATE_TOKEN_LENGTH` setting as `get_random_string` no longer has a default length
+- Remove Django 3.1 from test matrix
+- Remove Python 3.6 from test matrix
+- No longer build wheel as universal as Python 2 is not supported

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 Release type: patch
 
 - Add Django 4.0 support
-- Add `ELEVATE_TOKEN_LENGTH` setting as `get_random_string` no longer has a default length
+  - Add `ELEVATE_TOKEN_LENGTH` setting as `get_random_string` no longer has a default length
 - Remove Django 3.1 from test matrix
 - Remove Python 3.6 from test matrix
 - No longer build wheel as universal as Python 2 is not supported

--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -49,6 +49,9 @@ By default, all of the settings are optional and define sane and secure defaults
     The name of the session attribute used to preserve the redirect destination
     between the original page request and successful elevated login. *Default: elevate_redirect_to*
 
+``ELEVATE_TOKEN_LENGTH``
+    Length of the random string that is stored in the Elevate cookie. *Default: 12*
+
 Set up URLs
 ~~~~~~~~~~~
 

--- a/elevate/settings.py
+++ b/elevate/settings.py
@@ -45,3 +45,6 @@ REDIRECT_TO_FIELD_NAME = getattr(settings, 'ELEVATE_REDIRECT_TO_FIELD_NAME', 'el
 
 # The url for the Elevate page itself. May be a url or a view name
 URL = getattr(settings, 'ELEVATE_URL', 'elevate.views.elevate')
+
+# Length of the token stored in the cookie.
+TOKEN_LENGTH = getattr(settings, 'ELEVATE_TOKEN_LENGTH', 12)

--- a/elevate/utils.py
+++ b/elevate/utils.py
@@ -9,7 +9,7 @@ elevate.utils
 from django.core.signing import BadSignature
 from django.utils.crypto import get_random_string, constant_time_compare
 
-from elevate.settings import COOKIE_NAME, COOKIE_AGE, COOKIE_SALT
+from elevate.settings import COOKIE_NAME, COOKIE_AGE, COOKIE_SALT, TOKEN_LENGTH
 
 
 def grant_elevated_privileges(request, max_age=COOKIE_AGE):
@@ -28,7 +28,7 @@ def grant_elevated_privileges(request, max_age=COOKIE_AGE):
 
     # Token doesn't need to be unique,
     # just needs to be unpredictable and match the cookie and the session
-    token = get_random_string()
+    token = get_random_string(TOKEN_LENGTH)
     request.session[COOKIE_NAME] = token
     request._elevate = True
     request._elevate_token = token

--- a/elevate/views.py
+++ b/elevate/views.py
@@ -17,13 +17,18 @@ from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_protect
 from django.views.generic import View
 from django.utils.decorators import method_decorator
-from django.utils.http import is_safe_url
 from django.utils.module_loading import import_string
 
 from elevate.settings import (REDIRECT_FIELD_NAME, REDIRECT_URL,
                               REDIRECT_TO_FIELD_NAME, URL)
 from elevate.forms import ElevateForm
 from elevate.utils import grant_elevated_privileges
+
+try:
+    from django.utils.http import url_has_allowed_host_and_scheme
+except ImportError:
+    # Remove once Django 2.2 is EOL
+    from django.utils.http import is_safe_url as url_has_allowed_host_and_scheme
 
 
 class ElevateView(View):
@@ -45,8 +50,8 @@ class ElevateView(View):
         redirect_to = request.session.pop(REDIRECT_TO_FIELD_NAME,
                                           redirect_to)
         # Double check we're not redirecting to other sites
-        if not is_safe_url(redirect_to, allowed_hosts=[request.get_host()],
-                           require_https=request.is_secure()):
+        if not url_has_allowed_host_and_scheme(redirect_to, allowed_hosts=[request.get_host()],
+                                               require_https=request.is_secure()):
             redirect_to = resolve_url(REDIRECT_URL)
         return HttpResponseRedirect(redirect_to)
 
@@ -58,8 +63,8 @@ class ElevateView(View):
         redirect_to = request.GET.get(REDIRECT_FIELD_NAME, REDIRECT_URL)
 
         # Make sure we're not redirecting to other sites
-        if not is_safe_url(redirect_to, allowed_hosts=[request.get_host()],
-                           require_https=request.is_secure()):
+        if not url_has_allowed_host_and_scheme(redirect_to, allowed_hosts=[request.get_host()],
+                                               require_https=request.is_secure()):
             redirect_to = resolve_url(REDIRECT_URL)
 
         if request.is_elevated():

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,3 @@ python_files = tests/*.py
 
 [flake8]
 max-line-length = 100
-
-[wheel]
-universal = 1

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/tests/middleware.py
+++ b/tests/middleware.py
@@ -10,7 +10,7 @@ from .base import BaseTestCase
 
 
 class ElevateMiddlewareTestCase(BaseTestCase):
-    middleware = ElevateMiddleware()
+    middleware = ElevateMiddleware(lambda x: x)
 
     def assertSignedCookieEqual(self, v1, v2, reason=None):
         value, _, _ = v1.split(':')

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from elevate import views
 
 
 urlpatterns = [
-    url(r'^elevate/', views.elevate, name='elevate'),
+    re_path(r'^elevate/', views.elevate, name='elevate'),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,16 @@
 [tox]
 envlist =
-    py{py3,36,37,38}-django22
-    py{36,37,38,39,310}-django{31,32}
+    py{py3,37,38}-django22
+    py37-django32
+    py{38,39,310}-django{32,40}
     docs
     flake8
 
 [testenv]
 deps =
     django22: Django>=2.2,<2.3
-    django31: Django>=3.1,<3.2
     django32: Django>=3.2,<3.3
+    django40: Django>=4.0,<4.1
     coverage
     pytest
     pytest-cov
@@ -18,7 +19,6 @@ commands = pytest --cov=elevate --cov-report=xml {posargs}
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39


### PR DESCRIPTION
- Added Django 4.0 support
  - Added ELEVATE_TOKEN_LENGTH setting as `get_random_string` no longer
    has a default length
- Removed Django 3.1 from test matrix
- Removed Python 3.6 from test matrix
- No longer build wheel as universal - we don't support Python 2